### PR TITLE
Fix task prioritization bug

### DIFF
--- a/src/main/java/com/codingame/game/CommandManager.java
+++ b/src/main/java/com/codingame/game/CommandManager.java
@@ -235,7 +235,7 @@ public class CommandManager {
             }
             CardType cardType = CardType.values()[cardTypeToThrow];
             int cardsCount = (int)player.getCardsInHand().stream().filter(c -> c.getCardType().equals(cardType)).count();
-            if (cardsCount==0 || (cardsCount==1 && cardType.equals(CardType.CONTINUOUS_INTEGRATION))) {
+            if (cardsCount==0 || (cardsCount==1 && cardType.equals(CardType.TASK_PRIORITIZATION))) {
                 throw new GameRuleException(command, String.format("you do not have a card of type %s to deprioritize", cardType));
             }
             int cardTypeToTake = Integer.parseInt(match.group("cardTypeToTake"));


### PR DESCRIPTION
Playing TASK_PRIORITIZATION should check we have more than 0 cards of
the type we want to throw, and more than 1 card if we want to throw
TASK_PRIORITIZATION.

Instead, it makes this check for CONTINUOUS_INTEGRATION (possibly copied
from line 274?), requiring the player to have 2 cards of the latter type
if they want to throw that card away.